### PR TITLE
chore: remove requireIndex dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "email": "sabbir.m.siddiqui@gmail.com"
   },
   "bundleDependencies": false,
-  "dependencies": {
-    "requireindex": "~1.1.0"
-  },
   "deprecated": false,
   "devDependencies": {
     "eslint": "~3.9.1",


### PR DESCRIPTION
```
npm error code E403
npm error 403 403 Forbidden - GET requireindex/-/requireindex-1.1.0.tgz
npm error 403 In most cases, you or one of your dependencies are requesting
npm error 403 a package version that is forbidden by your security policy, or
npm error 403 on a server you do not have access to.
```

This dependency is deprecated and thus break CI